### PR TITLE
feat: bump go-pq-cdc v1.8.9

### DIFF
--- a/benchmark/go-pq-cdc-kafka/go.mod
+++ b/benchmark/go-pq-cdc-kafka/go.mod
@@ -5,7 +5,7 @@ go 1.22.4
 replace github.com/Trendyol/go-pq-cdc-kafka => ../../
 
 require (
-	github.com/Trendyol/go-pq-cdc v1.6.8
+	github.com/Trendyol/go-pq-cdc v1.8.9
 	github.com/Trendyol/go-pq-cdc-kafka v0.0.1
 	github.com/segmentio/kafka-go v0.4.47
 )

--- a/benchmark/go-pq-cdc-kafka/go.sum
+++ b/benchmark/go-pq-cdc-kafka/go.sum
@@ -7,6 +7,8 @@ github.com/Trendyol/go-pq-cdc v1.2.6-0.20251229094218-18b776864109/go.mod h1:RIo
 github.com/Trendyol/go-pq-cdc v1.3.6/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
 github.com/Trendyol/go-pq-cdc v1.5.6/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
 github.com/Trendyol/go-pq-cdc v1.6.8/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
+github.com/Trendyol/go-pq-cdc v1.7.8/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
+github.com/Trendyol/go-pq-cdc v1.8.9/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
 github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
 github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Trendyol/go-pq-cdc-kafka
 go 1.22.4
 
 require (
-	github.com/Trendyol/go-pq-cdc v1.7.8
+	github.com/Trendyol/go-pq-cdc v1.8.9
 	github.com/docker/go-connections v0.5.0
 	github.com/lib/pq v1.10.9
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/Trendyol/go-pq-cdc v1.6.8 h1:mj+OhUl8KJSBZ8NyQNUVzNeaZQnS7w/kokdqSxiV
 github.com/Trendyol/go-pq-cdc v1.6.8/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
 github.com/Trendyol/go-pq-cdc v1.7.8 h1:HQRyGIfh3i8dgnI5XcuCLseJhjCPAY9P88ZtfZEpYfI=
 github.com/Trendyol/go-pq-cdc v1.7.8/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
+github.com/Trendyol/go-pq-cdc v1.8.9/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
 github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
 github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,7 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
-github.com/Trendyol/go-pq-cdc v1.6.8 h1:mj+OhUl8KJSBZ8NyQNUVzNeaZQnS7w/kokdqSxiV+kU=
-github.com/Trendyol/go-pq-cdc v1.6.8/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
-github.com/Trendyol/go-pq-cdc v1.7.8 h1:HQRyGIfh3i8dgnI5XcuCLseJhjCPAY9P88ZtfZEpYfI=
-github.com/Trendyol/go-pq-cdc v1.7.8/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
+github.com/Trendyol/go-pq-cdc v1.8.9 h1:UrzdayTawQRqar8TN9MAm3uRxr+FppkqMptWa1/zZVY=
 github.com/Trendyol/go-pq-cdc v1.8.9/go.mod h1:RIooS3DPOWkXxq7nhrOuGgkD4x3ondWEYOrOEHAHnxc=
 github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
 github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=


### PR DESCRIPTION
Upgrade `go-pq-cdc` dependency to v1.8.9.